### PR TITLE
feat: re-export equalizer interface

### DIFF
--- a/src/interfaces.cairo
+++ b/src/interfaces.cairo
@@ -25,6 +25,7 @@ pub use opus::interfaces::absorber::{
 pub use opus::interfaces::allocator::{IAllocatorDispatcher, IAllocatorDispatcherTrait};
 pub use opus::interfaces::caretaker::{ICaretakerDispatcher, ICaretakerDispatcherTrait};
 pub use opus::interfaces::controller::{IControllerDispatcher, IControllerDispatcherTrait};
+pub use opus::interfaces::equalizer::{IEqualizerDispatcher, IEqualizerDispatcherTrait};
 pub use opus::interfaces::flash_borrower::{
     IFlashBorrower, IFlashBorrowerDispatcher, IFlashBorrowerDispatcherTrait
 };


### PR DESCRIPTION
This PR re-exports Equalizer's interface for ease of import (I must have missed it previously). The plan is to cut a patch release `v1.0.1` once this is merged because I need it in another project.