### PR TITLE
chore: bump package version

### DIFF
--- a/Scarb.lock
+++ b/Scarb.lock
@@ -3,7 +3,7 @@ version = 1
 
 [[package]]
 name = "opus"
-version = "1.0.3"
+version = "1.1.0"
 dependencies = [
  "wadray",
 ]

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opus"
-version = "1.0.3"
+version = "1.1.0"
 edition = "2024_07"
 
 # See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest.html


### PR DESCRIPTION
This PR bumps the version of the package to `v1.1.0`.