### PR TITLE
chore: bump version to v1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,5 @@ To use this package, add the repository as a dependency in your Scarb.toml:
 
 ```
 [dependencies]
-opus = "1.0.1"
+opus = "1.2.0"
 ```

--- a/Scarb.lock
+++ b/Scarb.lock
@@ -8,7 +8,7 @@ source = "git+https://github.com/EkuboProtocol/abis#edb6de8c9baf515f1053bbab3d86
 
 [[package]]
 name = "opus"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "ekubo",
  "wadray",

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opus"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2024_07"
 
 # See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest.html


### PR DESCRIPTION
This PR bumps the version to v1.2.0.