### PR TITLE
fix: remove Ekubo dependency for stabilizer

### DIFF
--- a/Scarb.lock
+++ b/Scarb.lock
@@ -2,15 +2,9 @@
 version = 1
 
 [[package]]
-name = "ekubo"
-version = "0.1.0"
-source = "git+https://github.com/EkuboProtocol/abis#edb6de8c9baf515f1053bbab3d86825d54a63bc3"
-
-[[package]]
 name = "opus"
 version = "1.2.0"
 dependencies = [
- "ekubo",
  "wadray",
 ]
 

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -10,7 +10,6 @@ edition = "2024_07"
 [dependencies]
 starknet = ">= 2.8.0"
 wadray = ">= 0.5.0"
-ekubo = { git = "https://github.com/EkuboProtocol/abis", commit = "edb6de8c9baf515f1053bbab3d86825d54a63bc3" }
 
 [[target.starknet-contract]]
 sierra = true

--- a/src/interfaces.cairo
+++ b/src/interfaces.cairo
@@ -17,6 +17,7 @@ pub mod receptor;
 pub mod seer;
 pub mod sentinel;
 pub mod shrine;
+pub mod stabilizer;
 pub mod transmuter;
 
 pub use opus::interfaces::abbot::{IAbbotDispatcher, IAbbotDispatcherTrait};
@@ -51,4 +52,5 @@ pub use opus::interfaces::seer::{
 };
 pub use opus::interfaces::sentinel::{ISentinelDispatcher, ISentinelDispatcherTrait};
 pub use opus::interfaces::shrine::{IShrineDispatcher, IShrineDispatcherTrait};
+pub use opus::interfaces::stabilizer::{IStabilizerDispatcher, IStabilizerDispatcherTrait};
 pub use opus::interfaces::transmuter::{ITransmuterDispatcher, ITransmuterDispatcherTrait};

--- a/src/interfaces/stabilizer.cairo
+++ b/src/interfaces/stabilizer.cairo
@@ -13,7 +13,8 @@ pub trait IStabilizer<TContractState> {
     //
     // If you need to make use of these two functions, create a separate interface and add
     // this line to your Scarb.toml
-    // `ekubo = { git = "https://github.com/EkuboProtocol/abis", commit = "edb6de8c9baf515f1053bbab3d86825d54a63bc3" }`
+    // `ekubo = { git = "https://github.com/EkuboProtocol/abis", commit =
+    // "edb6de8c9baf515f1053bbab3d86825d54a63bc3" }`
 
     // fn get_pool_key(self: @TContractState) -> PoolKey;
     // fn get_bounds(self: @TContractState) -> Bounds;

--- a/src/interfaces/stabilizer.cairo
+++ b/src/interfaces/stabilizer.cairo
@@ -1,6 +1,4 @@
-use ekubo::types::bounds::Bounds;
-use ekubo::types::keys::PoolKey;
-use opus_compose::stabilizer::types::{Stake, YieldState};
+use opus::types::{Stake, YieldState};
 use starknet::ContractAddress;
 
 #[starknet::interface]
@@ -8,8 +6,18 @@ pub trait IStabilizer<TContractState> {
     //
     // Getters
     //
-    fn get_pool_key(self: @TContractState) -> PoolKey;
-    fn get_bounds(self: @TContractState) -> Bounds;
+
+    // These two functions have been commented out because Ekubo has not been published
+    // as a package on scarbs.xyz, and consequently it cannot be imported due to the
+    // requirement that a package must have a version specified.
+    //
+    // If you need to make use of these two functions, create a separate interface and add
+    // this line to your Scarb.toml
+    // `ekubo = { git = "https://github.com/EkuboProtocol/abis", commit = "edb6de8c9baf515f1053bbab3d86825d54a63bc3" }`
+
+    // fn get_pool_key(self: @TContractState) -> PoolKey;
+    // fn get_bounds(self: @TContractState) -> Bounds;
+
     fn get_total_liquidity(self: @TContractState) -> u128;
     fn get_token_id_for_user(self: @TContractState, user: ContractAddress) -> Option<u64>;
     // Note that this should not be used to check if a user has an active stake because


### PR DESCRIPTION
This PR removes Ekubo as a dependency due to issues encountered when trying to publish on scarbs.xyz. There is a requirement that packages have a version specified, but Ekubo is not published on scarbs.xyz. Therefore, functions that rely on Ekubo's types have been commented out.

Additionally, this PR fixes an omission to include the stabilizer interface for compilation as well as for export.